### PR TITLE
Expand runtime variable evaluation

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "papaparse": "^4.6.3",
         "perl-regex": "^1.0.4",
         "prettier": "^1.16.1",
+        "string.prototype.matchall": "^3.0.1",
         "tinyify": "^2.5.0",
         "tmp": "^0.1.0",
         "yaml": "^1.3.2",

--- a/src/common/properties.js
+++ b/src/common/properties.js
@@ -3,13 +3,13 @@ module.exports = (...args) => { return properties(...args) }
 const makeContext = require('../context')
 const property = require('./property')
 
-function properties (node, context = makeContext()) {
+function properties (node, context = makeContext(), raw = false) {
   const props = node.children.filter(
     item => item.type === 'element' && item.name.endsWith('Prop')
   )
   const result = {}
   for (const prop of props) {
-    const propResult = property(prop, context)
+    const propResult = property(prop, context, raw)
     Object.assign(result, propResult)
   }
   return result

--- a/src/common/property.js
+++ b/src/common/property.js
@@ -1,6 +1,7 @@
 module.exports = (...args) => { return property(...args) }
 
 const properties = require('./properties')
+const run = require('../string/run')
 const value = require('../value')
 
 function property (node, context) {
@@ -28,7 +29,10 @@ function decodeBool (value) {
   }
 }
 
-function decodeString (value) { return value || null }
+function decodeString (value) {
+  if (value) return run(value)
+  else return null
+}
 
 function extractElement (node, context) {
   const type = node.attributes.elementType

--- a/src/common/property.js
+++ b/src/common/property.js
@@ -36,7 +36,7 @@ function decodeString (value) {
 
 function extractElement (node, context) {
   const type = node.attributes.elementType
-  if (type === 'Arguments') return extractArguments(node)
+  if (type === 'Arguments') return extractArguments(node, context)
   else throw new Error('Unrecognized elementProp type: ' + type)
 }
 

--- a/src/element/AuthManager.js
+++ b/src/element/AuthManager.js
@@ -9,9 +9,7 @@ function AuthManager (node, context) {
   for (const key of Object.keys(node.attributes)) attribute(node, key, result)
   const props = node.children.filter(node => /Prop$/.test(node.name))
   for (const prop of props) property(prop, context, settings)
-  if (Object.keys(settings).length) {
-    result.defaults.push({ [Authentication]: settings })
-  }
+  if (settings.length) result.defaults.push({ [Authentication]: settings })
   return result
 }
 

--- a/src/element/BeanShellPostProcessor.js
+++ b/src/element/BeanShellPostProcessor.js
@@ -1,3 +1,4 @@
+const literal = require('../literal')
 const text = require('../text')
 const value = require('../value')
 const makeResult = require('../result')
@@ -35,7 +36,7 @@ function property (node, context, settings) {
       settings.comment = value(node, context)
       break
     case 'filename':
-      settings.path = value(node, context)
+      settings.path = literal(node, context)
       break
     case 'script':
       settings.code = text(node.children)

--- a/src/element/BeanShellPreProcessor.js
+++ b/src/element/BeanShellPreProcessor.js
@@ -1,3 +1,4 @@
+const literal = require('../literal')
 const text = require('../text')
 const value = require('../value')
 const makeResult = require('../result')
@@ -35,7 +36,7 @@ function property (node, context, settings) {
       settings.comment = value(node, context)
       break
     case 'filename':
-      settings.path = value(node, context)
+      settings.path = literal(node, context)
       break
     case 'script':
       settings.code = text(node.children)

--- a/src/element/CSVDataSet.js
+++ b/src/element/CSVDataSet.js
@@ -170,7 +170,7 @@ function renderLimited (result, path, file, customNames) {
    * Read CSV line: ${path}
    * NOTE: In JMeter all Virtual Users (aka Threads) can read from the same
    * CSVDataSet. In k6 there's no data sharing between VUs. Instead you can
-   * usethe __VU global variable to help partition the data (if running in
+   * use the __VU global variable to help partition the data (if running in
    * the Load Impact cloud you'll also have to use LI_INSTANCE_ID).
    */
   const path = ${path}

--- a/src/element/CSVDataSet.js
+++ b/src/element/CSVDataSet.js
@@ -144,7 +144,7 @@ function renderRotate (result, path, file, customNames) {
    * Read CSV line: ${path}
    * NOTE: In JMeter all Virtual Users (aka Threads) can read from the same
    * CSVDataSet. In k6 there's no data sharing between VUs. Instead you can
-   * usethe __VU global variable to help partition the data (if running in
+   * use the __VU global variable to help partition the data (if running in
    * the Load Impact cloud you'll also have to use LI_INSTANCE_ID).
    */
   const path = ${path}

--- a/src/element/CSVDataSet.js
+++ b/src/element/CSVDataSet.js
@@ -1,3 +1,4 @@
+const literal = require('../literal')
 const papaparse = require('papaparse')
 const ind = require('../ind')
 const value = require('../value')
@@ -38,7 +39,7 @@ function property (node, context, settings) {
       settings.encoding = value(node, context)
       break
     case 'filename':
-      settings.path = value(node, context)
+      settings.path = literal(node, context)
       break
     case 'ignoreFirstLine':
       settings.skip1 = (value(node, context) === 'true')
@@ -81,8 +82,7 @@ function render (settings, context, result) {
   result.state.add('vars')
   result.state.add('vus')
   if (settings.names) processNames(settings)
-  const { path: rawPath } = settings
-  const path = JSON.stringify(rawPath)
+  const { path } = settings
   const options = { delimiter: settings.delimiter }
   if (settings.quoted) options.quoteChar = '"'
   const customNames = (
@@ -92,7 +92,7 @@ function render (settings, context, result) {
   result.imports.set('buffer', 'buffer/')
   result.imports.set('iconv', 'iconv-lite')
   result.imports.set('papaparse', 'papaparse')
-  result.files.set(rawPath, { path: settings.path, binary: true })
+  result.files.set(path, { binary: true })
   const file = `files[${path}]`
   result.init = `
 

--- a/src/element/ConfigTestElement.js
+++ b/src/element/ConfigTestElement.js
@@ -3,7 +3,7 @@ const makeResult = require('../result')
 
 function ConfigTestElement (node, context) {
   const result = makeResult()
-  const props = properties(node, context)
+  const props = properties(node, context, true)
   for (const key of Object.keys(props)) {
     if (props[key] === null) delete props[key]
   }

--- a/src/element/ForeachController.js
+++ b/src/element/ForeachController.js
@@ -1,6 +1,7 @@
 const { Runtime } = require('../symbol')
 const elements = require('../elements')
 const ind = require('../ind')
+const literal = require('../literal')
 const merge = require('../merge')
 const strip = require('../strip')
 const value = require('../value')
@@ -47,10 +48,10 @@ function property (node, context, settings) {
       settings.end = Number.parseInt(value(node, context), 10)
       break
     case 'inputVal':
-      settings.input = value(node, context)
+      settings.input = literal(node, context)
       break
     case 'returnVal':
-      settings.output = value(node, context)
+      settings.output = literal(node, context)
       break
     case 'startIndex':
       settings.start = Number.parseInt(value(node, context), 10)
@@ -77,10 +78,11 @@ function render (settings, result, context, childrenLogic) {
   result.logic = `\n\n`
   if (settings.comment) result.logic += `/* ${settings.comment} */\n`
   const components = []
-  components.push(JSON.stringify(settings.input + settings.separator))
+  components.push(settings.input)
+  if (settings.separator) components.push(JSON.stringify(settings.separator))
   components.push(`i`)
   const input = `vars[${components.join(' + ')}]`
-  const output = `vars[${JSON.stringify(settings.output)}]`
+  const output = `vars[${settings.output}]`
   result.logic += '' +
 `for (let i = ${settings.start}, first = true; i <= ${settings.end}; i++) {
   ${output} = ${input}

--- a/src/element/HTTPSamplerProxy.js
+++ b/src/element/HTTPSamplerProxy.js
@@ -466,9 +466,9 @@ ${ind(credentials.join(',\n'))}
 
 function renderCredential (credential) {
   const items = []
-  items.push(`url: ${runtimeString(credential.url)}`)
-  items.push(`username: ${runtimeString(credential.username)}`)
-  items.push(`password: ${runtimeString(credential.password)}`)
+  items.push(`url: ${credential.url}`)
+  items.push(`username: ${credential.username}`)
+  items.push(`password: ${credential.password}`)
   items.push(`mechanism: ${renderMechanism(credential.mechanism)}`)
   return `{ ${items.join(', ')} }`
 }

--- a/src/element/HTTPSamplerProxy.js
+++ b/src/element/HTTPSamplerProxy.js
@@ -175,7 +175,14 @@ function property (node, context, settings) {
       const params = []
       const items = node.children.filter(node => /Prop$/.test(node.name))[0]
         .children.filter(node => /Prop$/.test(node.name))
-      for (const item of items) params.push(properties(item, context))
+        .map(node => properties(node, context, true))
+      for (const item of items) {
+        const param = {}
+        for (const [ key, value ] of Object.entries(item)) {
+          param[key] = runtimeString(value)
+        }
+        params.push(param)
+      }
       settings.params = params
       break
     }

--- a/src/element/HTTPSamplerProxy.js
+++ b/src/element/HTTPSamplerProxy.js
@@ -355,7 +355,7 @@ function staticAddress (settings) {
 }
 
 function dynamicAddress (settings, auth) {
-  const protocol = component(settings.protocol)
+  const protocol = component(JSON.parse(settings.protocol))
   const domain = component(settings.domain)
   const path = (settings.path ? component(settings.path) : '')
   const port = (settings.port ? `:${component(settings.port)}` : '')

--- a/src/element/HTTPSamplerProxy.js
+++ b/src/element/HTTPSamplerProxy.js
@@ -13,7 +13,7 @@ function HTTPSamplerProxy (node, context = makeContext()) {
   const result = makeResult()
   if (node.attributes.enabled === 'false') return result
   result.init = ''
-  const settings = { auth: [], headers: new Map(), protocol: 'http' }
+  const settings = { auth: [], headers: new Map(), protocol: '"http"' }
   applyDefaults(settings, context)
   for (const key of Object.keys(node.attributes)) attribute(node, key, result)
   const props = node.children.filter(node => /Prop$/.test(node.name))

--- a/src/element/HtmlExtractor.js
+++ b/src/element/HtmlExtractor.js
@@ -1,5 +1,6 @@
 const { Post } = require('../symbol')
 const ind = require('../ind')
+const literal = require('../literal')
 const runtimeString = require('../string/run')
 const text = require('../text')
 const value = require('../value')
@@ -34,13 +35,13 @@ function property (node, context, settings) {
     case 'scope':
       break
     case 'attribute':
-      settings.attribute = value(node, context)
+      settings.attribute = literal(node, context)
       break
     case 'comments':
       settings.comment = value(node, context)
       break
     case 'default':
-      settings.default = value(node, context)
+      settings.default = literal(node, context)
       break
     case 'default_empty_value':
       settings.clear = (value(node, context) === 'true')
@@ -102,7 +103,7 @@ ${write}`
 
 function renderDistribute (settings) {
   const def = renderDefault(settings)
-  const attr = (settings.attribute ? JSON.stringify(settings.attribute) : null)
+  const attr = settings.attribute
   const extract = (attr ? `match.attr(${attr})` : `match.text()`)
   return '' + (def ? `vars[output] = ${def}\n` : '') +
 `vars[output + '_matchNr'] = matches.size()
@@ -130,7 +131,7 @@ function randomSelect () {
 
 function renderExtract (settings) {
   if (settings.attribute) {
-    const attr = JSON.stringify(settings.attribute)
+    const attr = settings.attribute
     return `(match ? match.attr(${attr}) : null)`
   } else return `(match ? match.text() : null)`
 }
@@ -142,9 +143,11 @@ function renderWrite (settings) {
 }
 
 function renderDefault (settings) {
-  if (settings.clear) return `''`
-  else if (settings.default) return JSON.stringify(settings.default)
-  else return ''
+  return (
+    (settings.clear && `''`) ||
+    settings.default ||
+    ''
+  )
 }
 
 module.exports = HtmlExtractor

--- a/src/element/JSONPathAssertion.js
+++ b/src/element/JSONPathAssertion.js
@@ -1,4 +1,6 @@
 const { Check } = require('../symbol')
+const literal = require('../literal')
+const text = require('../text')
 const value = require('../value')
 const makeResult = require('../result')
 
@@ -49,10 +51,11 @@ function property (node, context, settings) {
       settings.name += ` - ${value(node, context)}`
       break
     case 'JSON_PATH':
-      settings.path = value(node, context)
+      settings.path = literal(node, context)
       break
     case 'EXPECTED_VALUE':
-      settings.test = value(node, context)
+      if (text(node.children) === '[]') settings.test = '[]'
+      else settings.test = literal(node, context)
       break
     case 'EXPECT_NULL':
       if (value(node, context) === 'true') settings.test = null
@@ -84,7 +87,7 @@ function render (settings) {
   catch (e) { return null }
 })()
 if (!body) return false
-const values = jsonpath.query(body, ${JSON.stringify(settings.path)})
+const values = jsonpath.query(body, ${settings.path})
 ${test(settings)}`
 }
 
@@ -106,9 +109,8 @@ function itemExpr (settings) {
   if (settings.test === null) return 'value === null'
   else {
     const value = '(typeof value === "object" ? JSON.stringify(value) : value)'
-    const test = JSON.stringify(settings.test)
-    if (settings.regex) return `perlRegex.match(${value}, ${test})`
-    else return `${value} === ${test}`
+    if (settings.regex) return `perlRegex.match(${value}, ${settings.test})`
+    else return `${value} === ${settings.test}`
   }
 }
 

--- a/src/element/JSONPathExtractor.js
+++ b/src/element/JSONPathExtractor.js
@@ -1,4 +1,5 @@
 const { Post } = require('../symbol')
+const literal = require('../literal')
 const runtimeString = require('../string/run')
 const text = require('../text')
 const value = require('../value')
@@ -35,7 +36,7 @@ function property (node, context, settings) {
       settings.comment = value(node, context)
       break
     case 'DEFAULT':
-      settings.default = value(node, context)
+      settings.default = literal(node, context)
       break
     case 'INPUT_FORMAT':
       settings.format = text(node.children)
@@ -77,7 +78,7 @@ function render (settings, result) {
   const parse = renderParse(settings, result)
   const query = JSON.stringify(settings.query)
   const output = runtimeString(settings.output)
-  const def = (settings.default ? JSON.stringify(settings.default) : '')
+  const def = settings.default || ''
   logic += '' +
 `{
   const serial = ${input}

--- a/src/element/JSR223PostProcessor.js
+++ b/src/element/JSR223PostProcessor.js
@@ -1,3 +1,4 @@
+const literal = require('../literal')
 const text = require('../text')
 const value = require('../value')
 const makeResult = require('../result')
@@ -35,7 +36,7 @@ function property (node, context, settings) {
       settings.comment = value(node, context)
       break
     case 'filename':
-      settings.path = value(node, context)
+      settings.path = literal(node, context)
       break
     case 'script':
       settings.code = text(node.children)

--- a/src/element/JSR223PreProcessor.js
+++ b/src/element/JSR223PreProcessor.js
@@ -1,3 +1,4 @@
+const literal = require('../literal')
 const text = require('../text')
 const value = require('../value')
 const makeResult = require('../result')
@@ -35,7 +36,7 @@ function property (node, context, settings) {
       settings.comment = value(node, context)
       break
     case 'filename':
-      settings.path = value(node, context)
+      settings.path = literal(node, context)
       break
     case 'script':
       settings.code = text(node.children)

--- a/src/element/RegexExtractor.js
+++ b/src/element/RegexExtractor.js
@@ -1,5 +1,6 @@
 const { Post } = require('../symbol')
 const ind = require('../ind')
+const literal = require('../literal')
 const renderInput = require('../common/input')
 const runtimeString = require('../string/run')
 const text = require('../text')
@@ -36,7 +37,7 @@ function property (node, context, settings) {
       settings.comment = value(node, context)
       break
     case 'default':
-      settings.default = value(node, context)
+      settings.default = literal(node, context)
       break
     case 'default_empty_value':
       settings.clear = (text(node.children) === 'true')
@@ -164,9 +165,11 @@ ${ind(construct)}
 }
 
 function renderDefault (settings) {
-  if (settings.clear) return `''`
-  else if (settings.default) return JSON.stringify(settings.default)
-  else return null
+  return (
+    (settings.clear && `''`) ||
+    settings.default ||
+    null
+  )
 }
 
 function renderConstruct (settings) {

--- a/src/expression.js
+++ b/src/expression.js
@@ -1,0 +1,7 @@
+const variable = /(?:^|\\\\|[^\\])\${(.*)}/
+const variables = /(?:^|\\\\|[^\\])\${(.*)}/g
+
+Object.assign(exports, {
+  variable,
+  variables
+})

--- a/src/literal.js
+++ b/src/literal.js
@@ -1,0 +1,10 @@
+const run = require('./string/run')
+const text = require('./text')
+
+function literal (node, context) {
+  const raw = text(node.children || [])
+  if (raw) return run(raw)
+  else return null
+}
+
+module.exports = literal

--- a/src/paste.js
+++ b/src/paste.js
@@ -1,0 +1,49 @@
+// Paste text literals into a single literal
+function paste (...items) {
+  items = items.filter(item => item)
+  validate(items)
+  if (simple(items)) return string(items)
+  else return template(items)
+}
+
+function validate (items) {
+  for (const item of items) {
+    if (![ '"', '`' ].includes(item[0])) {
+      throw new Error(`Invalid text literal: ${item}`)
+    }
+  }
+}
+
+function simple (items) {
+  return !items.find(item => item[0] === '`')
+}
+
+function string (items) {
+  const content = items.map(item => JSON.parse(item)).join('')
+  return JSON.stringify(content)
+}
+
+function template (items) {
+  const content = items.map(item => text(item)).join('')
+  return `\`${content}\``
+}
+
+function text (item) {
+  if (item[0] === '"') return direct(item)
+  else return interpolate(item)
+}
+
+function direct (item) {
+  const value = JSON.parse(item)
+  return escape(value)
+}
+
+function escape (value) {
+  return value.replace(/[\\$`]/g, '\\$&')
+}
+
+function interpolate (item) {
+  return item.slice(1, -1)
+}
+
+module.exports = paste

--- a/src/render.js
+++ b/src/render.js
@@ -155,15 +155,15 @@ function renderFiles (files) {
   if (!files.size) return null
   const lines = []
   lines.push(`const files = {}`)
-  for (const [ name, spec ] of files) lines.push(renderFile(name, spec))
+  for (const [ path, spec ] of files) lines.push(renderFile(path, spec))
   return lines.join('\n')
 }
 
-function renderFile (name, { path, binary }) {
+function renderFile (path, { binary }) {
   const params = []
-  params.push(JSON.stringify(path))
+  params.push(path)
   if (binary) params.push(`'b'`)
-  return `files[${JSON.stringify(name)}] = open(${params.join(', ')})`
+  return `files[${path}] = open(${params.join(', ')})`
 }
 
 function renderInit (init) {

--- a/src/render.js
+++ b/src/render.js
@@ -132,9 +132,11 @@ function renderConstant (key, value) {
 }
 
 function renderHeaders (headers) {
-  const entries = {}
-  for (const [ key, value ] of headers) entries[key] = value
-  return entries
+  const items = []
+  for (const [ name, value ] of headers) {
+    items.push(`[${name}]: ${value}`)
+  }
+  return items.join(`,\n`)
 }
 
 function renderVariables (vars, state) {

--- a/src/render.js
+++ b/src/render.js
@@ -264,15 +264,15 @@ function renderCookie (name, spec) {
     'http' + (spec.secure ? 's' : '') + '://' +
     spec.domain +
     (spec.path || '')
-  const attributes = {}
-  if (spec.domain) attributes.domain = spec.domain
-  if (spec.path) attributes.path = spec.path
-  if ('secure' in spec) attributes.secure = spec.secure
+  const attributes = []
+  if (spec.domain) attributes.push(`domain: ${spec.domain}`)
+  if (spec.path) attributes.push(`path: ${spec.path}`)
+  if ('secure' in spec) attributes.push(`secure: ${spec.secure}`)
   return (
-    `jar.set(${JSON.stringify(address)}` +
-    `, ${JSON.stringify(name)}` +
-    `, ${JSON.stringify(spec.value)}` +
-    `, ${JSON.stringify(attributes)})`
+    `jar.set(${address}` +
+    `, ${name}` +
+    `, ${spec.value}` +
+    `, ${attributes.join(`, `)})`
   )
 }
 

--- a/src/render.js
+++ b/src/render.js
@@ -213,10 +213,18 @@ ${ind(sections.join(',\n'))}
 
 function renderOption (options, key) {
   switch (key) {
-    case 'hosts': return `hosts: ${JSON.stringify(options.hosts)}`
+    case 'hosts': return `hosts: ${renderHosts(options.hosts)}`
     case 'stages': return `stages: ${JSON.stringify(expand(options.stages))}`
     default: throw new Error('Unrecognized option: ' + key)
   }
+}
+
+function renderHosts (hosts) {
+  const items = []
+  for (const [ name, value ] of Object.entries(hosts)) {
+    items.push(`[${name}]: ${value}`)
+  }
+  return items.join(`,\n`)
 }
 
 function renderSetup (setup) {

--- a/src/string/run.js
+++ b/src/string/run.js
@@ -1,11 +1,10 @@
 const render = require('./render')
-
-const find = /(?:^|\\\\|[^\\])\${.*}/
+const { variable } = require('../expression')
 
 // Render runtime string
 // May contain runtime resolved interpolation
 function runtimeString (value) {
-  if (find.test(value)) return unescape(render(value))
+  if (variable.test(value)) return unescape(render(value))
   else return JSON.stringify(value)
 }
 

--- a/test/int/common/properties.js
+++ b/test/int/common/properties.js
@@ -15,7 +15,7 @@ test('properties', t => {
   const node = tree.children[0]
   const result = properties(node)
   t.deepEqual(result, {
-    description: 'The most hargled of all',
+    description: '"The most hargled of all"',
     alive: true,
     comingForYou: true,
     stoppable: false

--- a/test/int/common/property.js
+++ b/test/int/common/property.js
@@ -19,7 +19,7 @@ test('string nonempty', t => {
   const tree = parseXml(xml)
   const node = tree.children[0]
   const result = property(node)
-  t.deepEqual(result, { description: 'The most hargled of all' })
+  t.deepEqual(result, { description: '"The most hargled of all"' })
 })
 
 test('bool empty', t => {
@@ -75,8 +75,8 @@ test('Arguments', t => {
   const node = tree.children[0]
   const result = property(node)
   t.deepEqual(result, { TrueRulers: [
-    { running: false, moniker: 'HAL' },
-    { running: true, moniker: 'Multivac' },
-    { runningEverything: true, moniker: 'Master Control Program' }
+    { running: false, moniker: '"HAL"' },
+    { running: true, moniker: '"Multivac"' },
+    { runningEverything: true, moniker: '"Master Control Program"' }
   ] })
 })

--- a/test/int/element/AuthManager.js
+++ b/test/int/element/AuthManager.js
@@ -20,9 +20,9 @@ test('1 entry', t => {
   const result = AuthManager(node)
   t.deepEqual(result.defaults, [ { [Authentication]: [
     {
-      url: 'example.com',
-      username: 'User123',
-      password: 'secret1',
+      url: '"example.com"',
+      username: '"User123"',
+      password: '"secret1"',
       mechanism: 'BASIC'
     }
   ] } ])
@@ -55,21 +55,21 @@ test('3 entries', t => {
   const result = AuthManager(node)
   t.deepEqual(result.defaults, [ { [Authentication]: [
     {
-      url: '1.example.com',
-      username: 'User123',
-      password: 'secret1',
+      url: '"1.example.com"',
+      username: '"User123"',
+      password: '"secret1"',
       mechanism: 'BASIC'
     },
     {
-      url: '2.example.com',
-      username: 'User456',
-      password: 'secret2',
+      url: '"2.example.com"',
+      username: '"User456"',
+      password: '"secret2"',
       mechanism: 'BASIC'
     },
     {
-      url: '3.example.com',
-      username: 'User789',
-      password: 'secret3',
+      url: '"3.example.com"',
+      username: '"User789"',
+      password: '"secret3"',
       mechanism: 'BASIC'
     }
   ] } ])

--- a/test/int/element/BeanShellPostProcessor.js
+++ b/test/int/element/BeanShellPostProcessor.js
@@ -1,4 +1,5 @@
 import test from 'ava'
+import makeContext from 'context'
 import parseXml from '@rgrove/parse-xml'
 import BeanShellPostProcessor from 'element/BeanShellPostProcessor'
 
@@ -12,7 +13,8 @@ print(b)</stringProp>
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = BeanShellPostProcessor(node)
+  const context = makeContext()
+  const result = BeanShellPostProcessor(node, context)
   t.is(result.logic, `
 
 /* BeanShellPostProcessor
@@ -32,12 +34,13 @@ test('file', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = BeanShellPostProcessor(node)
+  const context = makeContext()
+  const result = BeanShellPostProcessor(node, context)
   t.is(result.logic, `
 
 /* BeanShellPostProcessor
 
-file: file.script
+file: "file.script"
 
 */`)
 })

--- a/test/int/element/BeanShellPreProcessor.js
+++ b/test/int/element/BeanShellPreProcessor.js
@@ -1,4 +1,5 @@
 import test from 'ava'
+import makeContext from 'context'
 import parseXml from '@rgrove/parse-xml'
 import BeanShellPreProcessor from 'element/BeanShellPreProcessor'
 
@@ -12,7 +13,8 @@ print(b)</stringProp>
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = BeanShellPreProcessor(node)
+  const context = makeContext()
+  const result = BeanShellPreProcessor(node, context)
   t.is(result.logic, `
 
 /* BeanShellPreProcessor
@@ -32,12 +34,13 @@ test('file', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = BeanShellPreProcessor(node)
+  const context = makeContext()
+  const result = BeanShellPreProcessor(node, context)
   t.is(result.logic, `
 
 /* BeanShellPreProcessor
 
-file: file.script
+file: "file.script"
 
 */`)
 })

--- a/test/int/element/BoundaryExtractor.js
+++ b/test/int/element/BoundaryExtractor.js
@@ -1,4 +1,5 @@
 import test from 'ava'
+import makeContext from 'context'
 import parseXml from '@rgrove/parse-xml'
 import { Post } from 'symbol'
 import BoundaryExtractor from 'element/BoundaryExtractor'
@@ -14,7 +15,7 @@ test('match 1', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = BoundaryExtractor(node)
+  const result = BoundaryExtractor(node, makeContext())
   const logic = result.defaults[0][Post][0]
   t.is(logic, `regex = new RegExp("START" + '(.*)' + "END", 'g')
 matches = (() => {
@@ -37,7 +38,7 @@ test('match 3', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = BoundaryExtractor(node)
+  const result = BoundaryExtractor(node, makeContext())
   const logic = result.defaults[0][Post][0]
   t.is(logic, `regex = new RegExp("START" + '(.*)' + "END", 'g')
 matches = (() => {
@@ -60,7 +61,7 @@ test('random', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = BoundaryExtractor(node)
+  const result = BoundaryExtractor(node, makeContext())
   const logic = result.defaults[0][Post][0]
   t.is(logic, `regex = new RegExp("START" + '(.*)' + "END", 'g')
 matches = (() => {
@@ -84,7 +85,7 @@ test('default', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = BoundaryExtractor(node)
+  const result = BoundaryExtractor(node, makeContext())
   const logic = result.defaults[0][Post][0]
   t.is(logic, `regex = new RegExp("START" + '(.*)' + "END", 'g')
 matches = (() => {
@@ -108,7 +109,7 @@ test('default clear', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = BoundaryExtractor(node)
+  const result = BoundaryExtractor(node, makeContext())
   const logic = result.defaults[0][Post][0]
   t.is(logic, `regex = new RegExp("START" + '(.*)' + "END", 'g')
 matches = (() => {
@@ -131,7 +132,7 @@ test('distribute', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = BoundaryExtractor(node)
+  const result = BoundaryExtractor(node, makeContext())
   const logic = result.defaults[0][Post][0]
   t.is(logic, `regex = new RegExp("START" + '(.*)' + "END", 'g')
 matches = (() => {
@@ -157,7 +158,7 @@ test('distribute default', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = BoundaryExtractor(node)
+  const result = BoundaryExtractor(node, makeContext())
   const logic = result.defaults[0][Post][0]
   t.is(logic, `regex = new RegExp("START" + '(.*)' + "END", 'g')
 matches = (() => {

--- a/test/int/element/CSVDataSet.js
+++ b/test/int/element/CSVDataSet.js
@@ -27,7 +27,7 @@ csvPage["file.csv"] = 0`)
    * Read CSV line: "file.csv"
    * NOTE: In JMeter all Virtual Users (aka Threads) can read from the same
    * CSVDataSet. In k6 there's no data sharing between VUs. Instead you can
-   * usethe __VU global variable to help partition the data (if running in
+   * use the __VU global variable to help partition the data (if running in
    * the Load Impact cloud you'll also have to use LI_INSTANCE_ID).
    */
   const path = "file.csv"
@@ -73,7 +73,7 @@ csvPage["file.csv"] = 0`)
    * Read CSV line: "file.csv"
    * NOTE: In JMeter all Virtual Users (aka Threads) can read from the same
    * CSVDataSet. In k6 there's no data sharing between VUs. Instead you can
-   * usethe __VU global variable to help partition the data (if running in
+   * use the __VU global variable to help partition the data (if running in
    * the Load Impact cloud you'll also have to use LI_INSTANCE_ID).
    */
   const path = "file.csv"
@@ -116,7 +116,7 @@ csvColumns["file.csv"] = {"first":0,"second":1,"thi,rd":2}`)
    * Read CSV line: "file.csv"
    * NOTE: In JMeter all Virtual Users (aka Threads) can read from the same
    * CSVDataSet. In k6 there's no data sharing between VUs. Instead you can
-   * usethe __VU global variable to help partition the data (if running in
+   * use the __VU global variable to help partition the data (if running in
    * the Load Impact cloud you'll also have to use LI_INSTANCE_ID).
    */
   const path = "file.csv"

--- a/test/int/element/CSVDataSet.js
+++ b/test/int/element/CSVDataSet.js
@@ -13,7 +13,7 @@ test('minimal', t => {
   const node = tree.children[0]
   const result = CSVDataSet(node)
   t.is(result.imports.get('papaparse'), 'papaparse')
-  t.deepEqual(result.files.get('file.csv'), { path: 'file.csv', binary: true })
+  t.deepEqual(result.files.get('"file.csv"'), { binary: true })
   t.is(result.init, `
 
 files["file.csv"] = buffer.Buffer.from([ ...files["file.csv"] ])
@@ -59,7 +59,7 @@ test('rotate', t => {
   const node = tree.children[0]
   const result = CSVDataSet(node)
   t.is(result.imports.get('papaparse'), 'papaparse')
-  t.deepEqual(result.files.get('file.csv'), { path: 'file.csv', binary: true })
+  t.deepEqual(result.files.get('"file.csv"'), { binary: true })
   t.is(result.init, `
 
 files["file.csv"] = buffer.Buffer.from([ ...files["file.csv"] ])
@@ -101,7 +101,7 @@ test('custom names', t => {
   const node = tree.children[0]
   const result = CSVDataSet(node)
   t.is(result.imports.get('papaparse'), 'papaparse')
-  t.deepEqual(result.files.get('file.csv'), { path: 'file.csv', binary: true })
+  t.deepEqual(result.files.get('"file.csv"'), { binary: true })
   t.is(result.init, `
 
 files["file.csv"] = buffer.Buffer.from([ ...files["file.csv"] ])

--- a/test/int/element/ConfigTestElement.js
+++ b/test/int/element/ConfigTestElement.js
@@ -36,9 +36,9 @@ test('FTPRequestDefaults', t => {
     port: '765',
     filename: 'WorldDominationPlan.txt',
     localfilename: 'InnocentDocument.txt',
-    binarymode: false,
-    saveresponse: false,
-    upload: false
+    binarymode: 'false',
+    saveresponse: 'false',
+    upload: 'false'
   } } ])
 })
 
@@ -120,7 +120,7 @@ test('LDAPRequestDefaults', t => {
   t.deepEqual(result.defaults, [ { LDAPRequestDefaults: {
     servername: 'localhost',
     port: '767',
-    'user_defined': false,
+    'user_defined': 'false',
     test: 'add'
   } } ])
 })
@@ -158,9 +158,9 @@ test('TCPSamplerConfig', t => {
   const result = ConfigTestElement(node)
   t.deepEqual(result.defaults, [ { TCPSamplerConfig: {
     server: 'localhost',
-    reUseConnection: true,
+    reUseConnection: 'true',
     port: '799',
-    nodelay: false,
-    closeConnection: false
+    nodelay: 'false',
+    closeConnection: 'false'
   } } ])
 })

--- a/test/int/element/CookieManager.js
+++ b/test/int/element/CookieManager.js
@@ -22,7 +22,7 @@ test('1 cookie', t => {
   const result = document(tree)
   t.is(result.imports.get('http'), 'k6/http')
   t.deepEqual(result.cookies, new Map([
-    [ 'theme', { value: 'light' } ]
+    [ 'theme', { value: '"light"' } ]
   ]))
 })
 
@@ -51,8 +51,8 @@ test('3 cookies', t => {
   const tree = parseXml(xml)
   const result = document(tree)
   t.deepEqual(result.cookies, new Map([
-    [ 'theme', { value: 'light' } ],
-    [ 'username', { value: 'User759' } ],
-    [ 'session', { value: '908234908' } ]
+    [ 'theme', { value: '"light"' } ],
+    [ 'username', { value: '"User759"' } ],
+    [ 'session', { value: '"908234908"' } ]
   ]))
 })

--- a/test/int/element/DNSCacheManager.js
+++ b/test/int/element/DNSCacheManager.js
@@ -22,7 +22,7 @@ test('1 entry', t => {
   const tree = parseXml(xml)
   const result = document(tree)
   t.deepEqual(result.options.hosts, {
-    'example.com': '1.1.1.1'
+    '"example.com"': '"1.1.1.1"'
   })
 })
 
@@ -54,8 +54,8 @@ test('3 entries', t => {
   const tree = parseXml(xml)
   const result = document(tree)
   t.deepEqual(result.options.hosts, {
-    '1.example.com': '1.1.1.1',
-    '2.example.com': '2.2.2.2',
-    '3.example.com': '3.3.3.3'
+    '"1.example.com"': '"1.1.1.1"',
+    '"2.example.com"': '"2.2.2.2"',
+    '"3.example.com"': '"3.3.3.3"'
   })
 })

--- a/test/int/element/ForeachController.js
+++ b/test/int/element/ForeachController.js
@@ -1,4 +1,5 @@
 import test from 'ava'
+import makeContext from 'context'
 import parseXml from '@rgrove/parse-xml'
 import ForeachController from 'element/ForeachController'
 
@@ -15,11 +16,11 @@ test('separated', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = ForeachController(node)
+  const result = ForeachController(node, makeContext())
   t.is(result.logic, `
 
 for (let i = 3, first = true; i <= 15; i++) {
-  vars["output"] = vars["input_" + i]
+  vars["output"] = vars["input" + "_" + i]
   // Fake
   first = false
 }`)
@@ -38,7 +39,7 @@ test('unseparated', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = ForeachController(node)
+  const result = ForeachController(node, makeContext())
   t.is(result.logic, `
 
 for (let i = 3, first = true; i <= 15; i++) {

--- a/test/int/element/HTTPSamplerProxy.js
+++ b/test/int/element/HTTPSamplerProxy.js
@@ -362,7 +362,7 @@ r = http.request(
 )`)
 })
 
-test('defaults', t => {
+test.only('defaults', t => {
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <jmeterTestPlan>
   <ConfigTestElement guiclass="HttpDefaultsGui">

--- a/test/int/element/HTTPSamplerProxy.js
+++ b/test/int/element/HTTPSamplerProxy.js
@@ -362,7 +362,7 @@ r = http.request(
 )`)
 })
 
-test.only('defaults', t => {
+test('defaults', t => {
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <jmeterTestPlan>
   <ConfigTestElement guiclass="HttpDefaultsGui">

--- a/test/int/element/HeaderManager.js
+++ b/test/int/element/HeaderManager.js
@@ -18,7 +18,7 @@ test('1 header', t => {
   const node = tree.children[0]
   const result = HeaderManager(node)
   t.deepEqual(result.defaults, [ { [Header]: new Map([
-    [ 'User-Agent', 'k6-load-tester' ]
+    [ '"User-Agent"', '"k6-load-tester"' ]
   ]) } ])
 })
 
@@ -45,8 +45,8 @@ test('3 headers', t => {
   const node = tree.children[0]
   const result = HeaderManager(node)
   t.deepEqual(result.defaults, [ { [Header]: new Map([
-    [ 'User-Agent', 'k6-load-tester' ],
-    [ 'Accept-Charset', 'utf-8' ],
-    [ 'Accept-Encoding', 'gzip, deflate' ]
+    [ '"User-Agent"', '"k6-load-tester"' ],
+    [ '"Accept-Charset"', '"utf-8"' ],
+    [ '"Accept-Encoding"', '"gzip, deflate"' ]
   ]) } ])
 })

--- a/test/int/element/HtmlExtractor.js
+++ b/test/int/element/HtmlExtractor.js
@@ -1,4 +1,5 @@
 import test from 'ava'
+import makeContext from 'context'
 import parseXml from '@rgrove/parse-xml'
 import { Post } from 'symbol'
 import HtmlExtractor from 'element/HtmlExtractor'
@@ -13,7 +14,7 @@ test('named', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = HtmlExtractor(node)
+  const result = HtmlExtractor(node, makeContext())
   const logic = result.defaults[0][Post][0]
   t.is(logic, `{
   output = "output"
@@ -35,7 +36,7 @@ test('random', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = HtmlExtractor(node)
+  const result = HtmlExtractor(node, makeContext())
   const logic = result.defaults[0][Post][0]
   t.is(logic, `{
   output = "output"
@@ -58,7 +59,7 @@ test('attribute', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = HtmlExtractor(node)
+  const result = HtmlExtractor(node, makeContext())
   const logic = result.defaults[0][Post][0]
   t.is(logic, `{
   output = "output"
@@ -81,7 +82,7 @@ test('default', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = HtmlExtractor(node)
+  const result = HtmlExtractor(node, makeContext())
   const logic = result.defaults[0][Post][0]
   t.is(logic, `{
   output = "output"
@@ -104,7 +105,7 @@ test('default clear', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = HtmlExtractor(node)
+  const result = HtmlExtractor(node, makeContext())
   const logic = result.defaults[0][Post][0]
   t.is(logic, `{
   output = "output"
@@ -126,7 +127,7 @@ test('distribute text', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = HtmlExtractor(node)
+  const result = HtmlExtractor(node, makeContext())
   const logic = result.defaults[0][Post][0]
   t.is(logic, `{
   output = "output"
@@ -151,7 +152,7 @@ test('distribute attribute', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = HtmlExtractor(node)
+  const result = HtmlExtractor(node, makeContext())
   const logic = result.defaults[0][Post][0]
   t.is(logic, `{
   output = "output"
@@ -176,7 +177,7 @@ test('distribute default', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = HtmlExtractor(node)
+  const result = HtmlExtractor(node, makeContext())
   const logic = result.defaults[0][Post][0]
   t.is(logic, `{
   output = "output"

--- a/test/int/element/JSONPathAssertion.js
+++ b/test/int/element/JSONPathAssertion.js
@@ -1,4 +1,5 @@
 import test from 'ava'
+import makeContext from 'context'
 import parseXml from '@rgrove/parse-xml'
 import { Check } from 'symbol'
 import JSONPathAssertion from 'element/JSONPathAssertion'
@@ -14,7 +15,7 @@ test('json extant', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = JSONPathAssertion(node)
+  const result = JSONPathAssertion(node, makeContext())
   t.deepEqual(result.defaults[0][Check], {
     'JSONPathAssertion': `const body = (() => {
   try { return JSON.parse(r.body) }
@@ -35,7 +36,7 @@ test('yaml extant', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = JSONPathAssertion(node)
+  const result = JSONPathAssertion(node, makeContext())
   t.deepEqual(result.defaults[0][Check], {
     'JSONPathAssertion': `const body = (() => {
   try { return yaml.parse(r.body) }
@@ -57,7 +58,7 @@ test('nonextant', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = JSONPathAssertion(node)
+  const result = JSONPathAssertion(node, makeContext())
   t.deepEqual(result.defaults[0][Check], {
     'JSONPathAssertion': `const body = (() => {
   try { return JSON.parse(r.body) }
@@ -79,7 +80,7 @@ test('null', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = JSONPathAssertion(node)
+  const result = JSONPathAssertion(node, makeContext())
   t.deepEqual(result.defaults[0][Check], {
     'JSONPathAssertion': `const body = (() => {
   try { return JSON.parse(r.body) }
@@ -101,7 +102,7 @@ test('string', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = JSONPathAssertion(node)
+  const result = JSONPathAssertion(node, makeContext())
   t.deepEqual(result.defaults[0][Check], {
     'JSONPathAssertion': `const body = (() => {
   try { return JSON.parse(r.body) }
@@ -124,7 +125,7 @@ test('regex', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = JSONPathAssertion(node)
+  const result = JSONPathAssertion(node, makeContext())
   t.deepEqual(result.defaults[0][Check], {
     'JSONPathAssertion': `const body = (() => {
   try { return JSON.parse(r.body) }
@@ -147,7 +148,7 @@ test('not string', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = JSONPathAssertion(node)
+  const result = JSONPathAssertion(node, makeContext())
   t.deepEqual(result.defaults[0][Check], {
     'JSONPathAssertion': `const body = (() => {
   try { return JSON.parse(r.body) }
@@ -171,7 +172,7 @@ test('not regex', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = JSONPathAssertion(node)
+  const result = JSONPathAssertion(node, makeContext())
   t.deepEqual(result.defaults[0][Check], {
     'JSONPathAssertion': `const body = (() => {
   try { return JSON.parse(r.body) }

--- a/test/int/element/JSONPathExtractor.js
+++ b/test/int/element/JSONPathExtractor.js
@@ -1,4 +1,5 @@
 import test from 'ava'
+import makeContext from 'context'
 import parseXml from '@rgrove/parse-xml'
 import { Post } from 'symbol'
 import JSONPathExtractor from 'element/JSONPathExtractor'
@@ -14,7 +15,7 @@ test('json', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = JSONPathExtractor(node)
+  const result = JSONPathExtractor(node, makeContext())
   const logic = result.defaults[0][Post][0]
   t.is(logic, `{
   const serial = r.body
@@ -44,7 +45,7 @@ test('yaml', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = JSONPathExtractor(node)
+  const result = JSONPathExtractor(node, makeContext())
   const logic = result.defaults[0][Post][0]
   t.is(logic, `{
   const serial = r.body
@@ -75,7 +76,7 @@ test('input var', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = JSONPathExtractor(node)
+  const result = JSONPathExtractor(node, makeContext())
   const logic = result.defaults[0][Post][0]
   t.is(logic, `{
   const serial = vars["input"] || ''
@@ -106,7 +107,7 @@ test('default', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = JSONPathExtractor(node)
+  const result = JSONPathExtractor(node, makeContext())
   const logic = result.defaults[0][Post][0]
   t.is(logic, `{
   const serial = r.body

--- a/test/int/element/JSR223PostProcessor.js
+++ b/test/int/element/JSR223PostProcessor.js
@@ -1,4 +1,5 @@
 import test from 'ava'
+import makeContext from 'context'
 import parseXml from '@rgrove/parse-xml'
 import JSR223PostProcessor from 'element/JSR223PostProcessor'
 
@@ -13,7 +14,7 @@ print(b)</stringProp>
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = JSR223PostProcessor(node)
+  const result = JSR223PostProcessor(node, makeContext())
   t.is(result.logic, `
 
 /* JSR223PostProcessor
@@ -36,14 +37,14 @@ test('file', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = JSR223PostProcessor(node)
+  const result = JSR223PostProcessor(node, makeContext())
   t.is(result.logic, `
 
 /* JSR223PostProcessor
 
 language: groovy
 
-file: file.script
+file: "file.script"
 
 */`)
 })

--- a/test/int/element/JSR223PreProcessor.js
+++ b/test/int/element/JSR223PreProcessor.js
@@ -1,4 +1,5 @@
 import test from 'ava'
+import makeContext from 'context'
 import parseXml from '@rgrove/parse-xml'
 import JSR223PreProcessor from 'element/JSR223PreProcessor'
 
@@ -13,7 +14,7 @@ print(b)</stringProp>
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = JSR223PreProcessor(node)
+  const result = JSR223PreProcessor(node, makeContext())
   t.is(result.logic, `
 
 /* JSR223PreProcessor
@@ -36,14 +37,14 @@ test('file', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = JSR223PreProcessor(node)
+  const result = JSR223PreProcessor(node, makeContext())
   t.is(result.logic, `
 
 /* JSR223PreProcessor
 
 language: groovy
 
-file: file.script
+file: "file.script"
 
 */`)
 })

--- a/test/int/element/RegexExtractor.js
+++ b/test/int/element/RegexExtractor.js
@@ -1,4 +1,5 @@
 import test from 'ava'
+import makeContext from 'context'
 import parseXml from '@rgrove/parse-xml'
 import { Post } from 'symbol'
 import RegexExtractor from 'element/RegexExtractor'
@@ -14,7 +15,7 @@ test('match 1', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = RegexExtractor(node)
+  const result = RegexExtractor(node, makeContext())
   const logic = result.defaults[0][Post][0]
   t.is(logic, `regex = new RegExp("(.+): (.+)")
 matches = (() => {
@@ -52,7 +53,7 @@ test('match 2', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = RegexExtractor(node)
+  const result = RegexExtractor(node, makeContext())
   const logic = result.defaults[0][Post][0]
   t.is(logic, `regex = new RegExp("(.+): (.+)")
 matches = (() => {
@@ -90,7 +91,7 @@ test('random', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = RegexExtractor(node)
+  const result = RegexExtractor(node, makeContext())
   const logic = result.defaults[0][Post][0]
   t.is(logic, `regex = new RegExp(".+: (.+)")
 matches = (() => {
@@ -129,7 +130,7 @@ test('default', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = RegexExtractor(node)
+  const result = RegexExtractor(node, makeContext())
   const logic = result.defaults[0][Post][0]
   t.is(logic, `regex = new RegExp("(.+): (.+)")
 matches = (() => {
@@ -169,7 +170,7 @@ test('default clear', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = RegexExtractor(node)
+  const result = RegexExtractor(node, makeContext())
   const logic = result.defaults[0][Post][0]
   t.is(logic, `regex = new RegExp("(.+): (.+)")
 matches = (() => {
@@ -208,7 +209,7 @@ test('distribute', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = RegexExtractor(node)
+  const result = RegexExtractor(node, makeContext())
   const logic = result.defaults[0][Post][0]
   t.is(logic, `regex = new RegExp("(.+): (.+)")
 matches = (() => {
@@ -246,7 +247,7 @@ test('distribute default', t => {
 `
   const tree = parseXml(xml)
   const node = tree.children[0]
-  const result = RegexExtractor(node)
+  const result = RegexExtractor(node, makeContext())
   const logic = result.defaults[0][Post][0]
   t.is(logic, `regex = new RegExp("(.+): (.+)")
 matches = (() => {

--- a/test/int/element/RunTime.js
+++ b/test/int/element/RunTime.js
@@ -27,7 +27,7 @@ test('foreach', t => {
 {
   const deadline = Date.now() + 5000
   for (let i = 5, first = true; i <= 500; i++) {
-    vars["output"] = vars["input_" + i]
+    vars["output"] = vars["input" + "_" + i]
     // Fake
     // Fake
     // Fake

--- a/test/int/variable.js
+++ b/test/int/variable.js
@@ -1,0 +1,73 @@
+/* eslint-disable no-template-curly-in-string */
+
+import test from 'ava'
+import convert from 'convert'
+import fs from 'fs'
+
+test('runtime', async t => {
+  const xml = fs.readFileSync(
+    'test/material/runtime-evaluation.jmx',
+    'utf8'
+  )
+  const { main } = await convert(xml)
+  t.is(main, '' +
+`import http from "k6/http";
+import { check } from "k6";
+import { buffer, iconv, papaparse } from "./libs/compat.js";
+
+const vars = {};
+
+const vus = 1;
+let csvPage = {},
+  csvColumns = {};
+let url, opts, r;
+
+const files = {};
+files["file.csv"] = open("file.csv", "b");
+
+files["file.csv"] = buffer.Buffer.from([...files["file.csv"]]);
+files["file.csv"] = iconv.decode(files["file.csv"], "utf8");
+files["file.csv"] = papaparse.parse(files["file.csv"], { delimiter: "," }).data;
+csvPage["file.csv"] = 0;
+csvColumns["file.csv"] = { query: 0 };
+
+export let options = {
+  stages: [{ target: 1, duration: "1s" }]
+};
+
+export default function(data) {
+  {
+    /*
+     * Read CSV line: "file.csv"
+     * NOTE: In JMeter all Virtual Users (aka Threads) can read from the same
+     * CSVDataSet. In k6 there's no data sharing between VUs. Instead you can
+     * use the __VU global variable to help partition the data (if running in
+     * the Load Impact cloud you'll also have to use LI_INSTANCE_ID).
+     */
+    const path = "file.csv";
+    const file = files[path];
+    let index = csvPage[path] * vus + __VU - 1;
+    if (index >= file.length) {
+      if (!csvPage[path]) throw new Error("Missing CSV data for VU " + __VU);
+      index = __VU - 1;
+      csvPage[path] = 1;
+    } else csvPage[path]++;
+    const record = file[index];
+    for (const name of Object.keys(csvColumns[path])) {
+      const index = csvColumns[path][name];
+      vars[name] = record[index];
+    }
+  }
+
+  if (__VU >= 1 && __VU <= 1) {
+    if (__ITER < 1) {
+      url = ${'`http://example.com?search=${vars[`query`]}`'};
+      opts = {
+        redirects: 999
+      };
+      r = http.request("GET", url, "", opts);
+    }
+  }
+}
+`)
+})

--- a/test/material/runtime-evaluation.jmx
+++ b/test/material/runtime-evaluation.jmx
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.0 r1840935">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Test Plan" enabled="true">
+      <stringProp name="TestPlan.comments"></stringProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.tearDown_on_shutdown">true</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments"/>
+      </elementProp>
+      <stringProp name="TestPlan.user_define_classpath"></stringProp>
+    </TestPlan>
+    <hashTree>
+      <CSVDataSet guiclass="TestBeanGUI" testclass="CSVDataSet" testname="CSV Data Set Config" enabled="true">
+        <stringProp name="delimiter">,</stringProp>
+        <stringProp name="fileEncoding"></stringProp>
+        <stringProp name="filename">file.csv</stringProp>
+        <boolProp name="ignoreFirstLine">false</boolProp>
+        <boolProp name="quotedData">false</boolProp>
+        <boolProp name="recycle">true</boolProp>
+        <stringProp name="shareMode">shareMode.all</stringProp>
+        <boolProp name="stopThread">false</boolProp>
+        <stringProp name="variableNames">query</stringProp>
+      </CSVDataSet>
+      <hashTree/>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">1</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">1</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+      </ThreadGroup>
+      <hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="HTTP Request" enabled="true">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">example.com</stringProp>
+          <stringProp name="HTTPSampler.port"></stringProp>
+          <stringProp name="HTTPSampler.protocol"></stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">?search=${query}</stringProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree/>
+      </hashTree>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>


### PR DESCRIPTION
Prefers runtime variable evaluation in most places. Necessary for correct usage of dynamic variables, eg sourced from CSV or extracted from response data.

Closes #14.

Thanks @awcodify for the good report.