### PR TITLE
Nail jsonpath to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "fs-extra": "^7.0.1",
         "he": "^1.2.0",
         "iconv-lite": "^0.4.24",
-        "jsonpath": "^1.0.0",
+        "jsonpath": "1.0.1",
         "papaparse": "^4.6.3",
         "perl-regex": "^1.0.4",
         "prettier": "^1.16.1",


### PR DESCRIPTION
Nail `jsonpath` to v1.0.1.

v1.0.2 changed something that breaks building with browserify:
dchester/jsonpath#128 dchester/jsonpath#129

Sticks the package to the latest known working version until a fix for that issue is available.

Closes #16.