### PR TITLE
Preload optimizers

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -1,6 +1,7 @@
 const browserify = require('browserify')
 const fs = require('fs')
 const ind = require('./ind')
+const tinyify = require('tinyify')
 const tmp = require('tmp')
 
 async function buildCompat (imports) {
@@ -80,7 +81,7 @@ async function stageIndex (dir, index) {
 async function bundle (dir) {
   return new Promise((resolve, reject) => {
     const bundler = browserify(`${dir}/index.js`, { standalone: 'Compat' })
-    bundler.plugin('tinyify', { flat: false })
+    bundler.plugin(tinyify, { flat: false })
     bundler.bundle((error, buffer) => {
       if (error) {
         reject(error)


### PR DESCRIPTION
Improves robustness of optimizer loading.

Browserify docs show the current approach of passing plugin name to the library. But this seems not to work when installed globally. Preloading and passing the loaded module to the lib resolves this.

Closes #20.