### PR TITLE
Skip CacheManager entries as k6 has no cache

### DIFF
--- a/src/element.js
+++ b/src/element.js
@@ -12,6 +12,7 @@ const route = {
   Arguments: require('./element/Arguments'),
   BeanShellPostProcessor: require('./element/BeanShellPostProcessor'),
   BeanShellPreProcessor: require('./element/BeanShellPreProcessor'),
+  CacheManager: require('./element/Skipped'),
   CookieManager: require('./element/CookieManager'),
   CSVDataSet: require('./element/CSVDataSet'),
   DNSCacheManager: require('./element/DNSCacheManager'),

--- a/src/element/Skipped.js
+++ b/src/element/Skipped.js
@@ -6,7 +6,9 @@ function Skipped(node, _context) {
     parts.unshift(current.name);
     current = current.parent;
   }
-  return { init: `\n // Element skipped: ${parts.join('.')}` };
+  return {
+    init: `\n// Element skipped: ${parts.join('.')}`,
+  };
 }
 
 module.exports = Skipped;

--- a/src/render.js
+++ b/src/render.js
@@ -273,7 +273,7 @@ function renderOption(options, key) {
     case 'stages':
       return `stages: ${JSON.stringify(expand(options.stages), '', 2)}`;
     case 'noVUConnectionReuse':
-      return `noVUConnectionReuse: ${options.noVUConnectionReuse.toString()}`;
+      return options.noVUConnectionReuse ? 'noVUConnectionReuse: true' : '';
     default:
       throw new Error(`Unrecognized option: ${key}`);
   }


### PR DESCRIPTION
Given https://github.com/loadimpact/k6/issues/142#issuecomment-512731091, there really isn't that much to do about CacheManager entries in jmx files. Added a skip to prevent conversions from crashing.

This PR also changes `noVUConnectionReuse` to only be emitted when it's set to true.

closes #18 