### PR TITLE
[feat] migrated to grafana dockerhub org

### DIFF
--- a/.github/workflows/build-on-tag.yml
+++ b/.github/workflows/build-on-tag.yml
@@ -42,9 +42,9 @@ jobs:
             --username ${{ secrets.DOCKERHUB_USERNAME }} \
             --password-stdin
           export tag=${GITHUB_REF/refs\/tags\/v/}
-          docker build . -t loadimpact/jmeter-to-k6:$tag
+          docker build . -t grafana/jmeter-to-k6:$tag
           docker tag \
-            loadimpact/jmeter-to-k6:$tag \
-            loadimpact/jmeter-to-k6:latest
-          docker push loadimpact/jmeter-to-k6:$tag
-          docker push loadimpact/jmeter-to-k6:latest
+            grafana/jmeter-to-k6:$tag \
+            grafana/jmeter-to-k6:latest
+          docker push grafana/jmeter-to-k6:$tag
+          docker push grafana/jmeter-to-k6:latest

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Note that this will require you to run the converter with `node node_modules/jme
 Alternatively, you can install the tool from DockerHub:
 
 ```shell
-docker pull loadimpact/jmeter-to-k6
+docker pull grafana/jmeter-to-k6
 ```
 
 **Convert**:
@@ -49,7 +49,7 @@ npx jmeter-to-k6 example/full.jmx -o full
 Using the Docker image, you execute the tool as follows:
 
 ```shell
-docker run -it -v "/path/to/jmeter-files/:/output/" loadimpact/jmeter-to-k6 /output/MyTest.jmx -o /output/MyTestOutput/
+docker run -it -v "/path/to/jmeter-files/:/output/" grafana/jmeter-to-k6 /output/MyTest.jmx -o /output/MyTestOutput/
 ```
 
 and then execute the k6 test using:


### PR DESCRIPTION
Loadimpact dockerhub organization is being migrated to grafana one. Replaceing `loadimpact/jmeter-to-k6` with `grafana/jmeter-to-k6` here in this PR.